### PR TITLE
Fixed landscape starting bug.

### DIFF
--- a/app/src/main/java/org/secuso/privacyfriendlyminesweeper/activities/PlayActivity.java
+++ b/app/src/main/java/org/secuso/privacyfriendlyminesweeper/activities/PlayActivity.java
@@ -219,6 +219,12 @@ public class PlayActivity extends AppCompatActivity implements PlayRecyclerViewA
             }
         }
 
+        if (landscape && numberOfRows > numberOfColumns) {
+            int save = numberOfColumns;
+            numberOfColumns = numberOfRows;
+            numberOfRows = save;
+        }
+
         //Creating the right sized the PlayingField
         numberOfCells = numberOfRows * numberOfColumns;
         data = new int[numberOfRows][numberOfColumns];


### PR DESCRIPTION
If a game is started in landscape mode, the data is represented as in vertical mode. Changing to vertical mode would thus crash due to index out of bounce