### PR TITLE
#47 Add Show Board button to victory screen.

### DIFF
--- a/app/src/main/java/org/secuso/privacyfriendlyminesweeper/activities/PlayActivity.kt
+++ b/app/src/main/java/org/secuso/privacyfriendlyminesweeper/activities/PlayActivity.kt
@@ -26,13 +26,13 @@ import android.util.Log
 import android.view.Surface
 import android.view.View
 import android.widget.*
+import androidx.activity.result.contract.ActivityResultContracts
 import androidx.appcompat.app.AppCompatActivity
 import androidx.appcompat.widget.Toolbar
 import androidx.core.content.ContextCompat
 import androidx.core.content.res.ResourcesCompat
 import androidx.lifecycle.ViewModelProvider
 import androidx.recyclerview.widget.GridLayoutManager
-import androidx.recyclerview.widget.ItemTouchHelper
 import androidx.recyclerview.widget.LinearLayoutManager
 import androidx.recyclerview.widget.RecyclerView
 import org.secuso.privacyfriendlyminesweeper.R
@@ -94,6 +94,17 @@ class PlayActivity : AppCompatActivity(), BestTimeReaderReceiver {
         R.color.black,
         R.color.black
     )
+
+    private var victoryLauncher =
+        registerForActivityResult(ActivityResultContracts.StartActivityForResult()) { result ->
+            if (result.resultCode == RESULT_OK) {
+                val data: Intent? = result.data
+                val viewOnly = data?.getBooleanExtra("viewOnly", false)!!
+                if (!viewOnly) {
+                    finish()
+                }
+            }
+        }
 
 
     override fun onCreate(savedInstanceState: Bundle?) {
@@ -194,7 +205,7 @@ class PlayActivity : AppCompatActivity(), BestTimeReaderReceiver {
             lockActivityOrientation()
             val intent = Intent(this, VictoryScreen::class.java)
             intent.putExtras(parameter)
-            startActivityForResult(intent, 0)
+            victoryLauncher.launch(intent)
 
             //update general statistics (not for user-defined game mode)
 
@@ -355,21 +366,6 @@ class PlayActivity : AppCompatActivity(), BestTimeReaderReceiver {
             }
         )
         recyclerView.adapter = adapter
-    }
-
-    /**
-     * This method is used to close the PlayActivity when a button on the Victory Screen is pressed
-     * @param requestCode the Code for the request, should be 0 if all went well
-     * @param resultCode the Code for the result, should be RESULT_OK if nothing broke
-     * @param data the Intent of the Activity
-     */
-    override fun onActivityResult(requestCode: Int, resultCode: Int, data: Intent?) {
-        super.onActivityResult(requestCode, resultCode, data)
-        if (requestCode == 0) {
-            if (resultCode == RESULT_OK) {
-                finish()
-            }
-        }
     }
 
     /**

--- a/app/src/main/java/org/secuso/privacyfriendlyminesweeper/activities/VictoryScreen.java
+++ b/app/src/main/java/org/secuso/privacyfriendlyminesweeper/activities/VictoryScreen.java
@@ -107,27 +107,16 @@ public class VictoryScreen extends Activity{
 
         final Button ok = (Button) findViewById(R.id.victory_continue);
         final Button stats = (Button) findViewById(R.id.victory_statistics);
+        final Button show = (Button) findViewById(R.id.victory_show_board);
         final Button redo = (Button) findViewById(R.id.victory_redo);
-        ok.setOnClickListener(new View.OnClickListener(){
-            @Override
-            public void onClick(View view) {
-                toGameActivity();
-            }
-        });
 
-        stats.setOnClickListener(new View.OnClickListener(){
-            @Override
-            public void onClick(View view) {
-                toStatsActivity();
-            }
-        });
+        ok.setOnClickListener(view -> toGameActivity());
 
-        redo.setOnClickListener(new View.OnClickListener(){
-            @Override
-            public void onClick(View view) {
-                replaySameGamemode();
-            }
-        });
+        stats.setOnClickListener(view -> toStatsActivity());
+
+        redo.setOnClickListener(view -> replaySameGamemode());
+
+        show.setOnClickListener(view -> toShowBoardActivity());
 
         //result is important for the correct closing of the playactivity
         setResult(RESULT_OK, null);
@@ -139,6 +128,17 @@ public class VictoryScreen extends Activity{
     private void toGameActivity() {
         finish();
     }
+
+    /**
+     * This method closes the Victory screen to reveal the game board in a viewOnly mode.
+     */
+    private void toShowBoardActivity() {
+        Intent intent = new Intent(this, PlayActivity.class);
+        intent.putExtra("viewOnly", true);
+        setResult(RESULT_OK, intent);
+        finish();
+    }
+
     /**
      * This method starts the stat activity
      */

--- a/app/src/main/res/layout/activity_victory.xml
+++ b/app/src/main/res/layout/activity_victory.xml
@@ -61,13 +61,17 @@
         </Button>
 
         <Button
-            android:id="@+id/empty"
+            android:id="@+id/victory_show_board"
             android:layout_width="0dp"
             android:layout_height="match_parent"
+            android:layout_marginLeft="3dp"
+            android:layout_marginRight="3dp"
             android:layout_weight="1"
-            android:padding="2dp"
-            android:background="@color/transparent"
-            android:text="">
+            android:background="@drawable/button_disabled"
+            android:padding="4dp"
+            android:text="@string/showBoard"
+            android:textSize="12sp">
+
         </Button>
 
         <Button

--- a/app/src/main/res/values-de/strings.xml
+++ b/app/src/main/res/values-de/strings.xml
@@ -126,6 +126,7 @@
     <string name="gameMode">Modus</string>
     <string name="newBestTime">Neue Bestzeit!</string>
     <string name="statistics">Zur Statisik</string>
+    <string name="showBoard">Spielbrett anzeigen</string>
     <string name="replay">Versuchen wirs nochmal</string>
     <string name="ok">Alles klar!</string>
 

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -127,6 +127,7 @@
     <string name="gameMode">Mode</string>
     <string name="newBestTime">New best time!</string>
     <string name="statistics">Go to stats</string>
+    <string name="showBoard">Show game board</string>
     <string name="replay">Replay same gamemode</string>
     <string name="ok">OK!</string>
 


### PR DESCRIPTION
Added a button to the victory screen which will close the victory screen and reveal the board in a viewOnly/game stopped mode so that the user can see where they went wrong. From viewing the board, going "back" will return you to the main menu the same as pressing OK from the victory screen. 

This also replaces usage of the deprecated startActivityForResult() by using ActivityResultContracts.

Solves #47 